### PR TITLE
Add a missing dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ WriteMakefile(
         'File::HomeDir'         => 0,
         'JSON'                  => 0,
         'Log::Report'           => 0,
+        'LWP::Protocol::https'  => 0,
         'LWP::UserAgent'        => 0,
         'Moo'                   => 0,
         'String::Random'        => 0,


### PR DESCRIPTION
Brass uses https to communicate with its server and LWP needs this module to use https.