### PR TITLE
Update dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,6 @@ WriteMakefile(
         'Log::Report'                => 0,
         'LWP::Protocol::https'       => 0,
         'LWP::UserAgent'             => 0,
-        'String::Random'             => 0,
         'Term::ReadKey'              => 0,
         'Test::More'                 => 0,
         'Text::Markdown'             => 0,

--- a/lib/Brass/ConfigDB.pm
+++ b/lib/Brass/ConfigDB.pm
@@ -27,7 +27,6 @@ use Log::Report;
 use LWP::UserAgent;
 use Moo;
 use CtrlO::Crypt::XkcdPassword;
-use String::Random;
 use URI;
 use URI::QueryParam;
 


### PR DESCRIPTION
This builds on the changes in 413da3b53ada now that Brass no longer uses String::Random to generate passwords, or anywhere else.

This should make the test suite pass again in GitHub Actions.