### PR TITLE
Split on cert filenames

### DIFF
--- a/lib/Brass/API.pm
+++ b/lib/Brass/API.pm
@@ -185,7 +185,10 @@ get 'api/cert/' => sub {
         my %output;
         foreach my $cert (@certs)
         {
-            my $filename = $cert->cert->filename;
+            my $full_filename = $cert->cert->filename;
+            my @paths = split /\s*,\s*/, $full_filename;
+            foreach my $path (@paths) {
+            my $filename = $path;
             # Add final newline if it doesn't exist
             my $content = $cert->cert->content;
             $content .= "\n" unless $content =~ /\n$/;
@@ -201,6 +204,7 @@ get 'api/cert/' => sub {
                     file_user  => $cert->cert->file_user,
                     file_group => $cert->cert->file_group,
                 };
+            }
             }
         }
         $output = [values %output];

--- a/lib/Brass/API.pm
+++ b/lib/Brass/API.pm
@@ -186,25 +186,24 @@ get 'api/cert/' => sub {
         foreach my $cert (@certs)
         {
             my $full_filename = $cert->cert->filename;
-            my @paths = split /\s*,\s*/, $full_filename;
-            foreach my $path (@paths) {
-            my $filename = $path;
-            # Add final newline if it doesn't exist
-            my $content = $cert->cert->content;
-            $content .= "\n" unless $content =~ /\n$/;
-            if ($output{$filename})
-            {
-                $output{$filename}->{content} .= $content;
-            }
-            else {
-                $output{$filename} = {
-                    type       => $cert->cert->type,
-                    filename   => $filename,
-                    content    => $content,
-                    file_user  => $cert->cert->file_user,
-                    file_group => $cert->cert->file_group,
-                };
-            }
+            my @filenames = split /\s*,\s*/, $full_filename;
+            foreach my $filename (@filenames) {
+                # Add final newline if it doesn't exist
+                my $content = $cert->cert->content;
+                $content .= "\n" unless $content =~ /\n$/;
+                if ($output{$filename})
+                {
+                    $output{$filename}->{content} .= $content;
+                }
+                else {
+                    $output{$filename} = {
+                        type       => $cert->cert->type,
+                        filename   => $filename,
+                        content    => $content,
+                        file_user  => $cert->cert->file_user,
+                        file_group => $cert->cert->file_group,
+                    };
+                }
             }
         }
         $output = [values %output];


### PR DESCRIPTION
Renamed $filename to $full_filename

Added a split (on comma) to this this value to separate the different paths that might be listed within the certificate's filename.

Then added a loop to run through each path and treat it as a separate certificate filename. 

This allows certificates to be saved into multiple location/files by using a comma separated list in the filename field.